### PR TITLE
Download and flash firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Thumbs.db
 # qtcreator generated files
 *.pro.user*
 CMakeLists.txt.user*
+.cache
 
 # xemacs temporary files
 *.flc

--- a/flasher.h
+++ b/flasher.h
@@ -28,15 +28,20 @@ public:
 
 private:
     Ui::Flasher *ui;
-    QNetworkAccessManager manager;
+    QDir cacheDir;
+    QFile firmwareFile;
     QHash<QString, QSerialPortInfo> serialPortsHash;
+    QNetworkAccessManager manager;
     QSerialPort serialPort;
     QProcess process;
     QString esptoolPath;
+
     void setOutput(QString message);
     void appendOutput(QString message);
+    void appendOutputLine(QString message);
 
 private slots:
+    void reloadSerialPorts();
     void downloadFirmware();
     void sslErrors(const QList<QSslError> &sslErrors);
     void firmwareDownloaded(QNetworkReply *reply);
@@ -45,5 +50,6 @@ private slots:
     void readProcess();
     void serialError(QSerialPort::SerialPortError error);
     void flashSerial();
+    void flashFinished();
 };
 #endif // FLASHER_H

--- a/flasher.ui
+++ b/flasher.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>333</width>
-    <height>424</height>
+    <width>424</width>
+    <height>473</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,6 +20,9 @@
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
      <widget class="QLineEdit" name="usernameEdit">
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
       <property name="placeholderText">
        <string>Enter your raise.dev username</string>
       </property>
@@ -29,6 +32,9 @@
      <widget class="QLineEdit" name="passwordEdit">
       <property name="echoMode">
        <enum>QLineEdit::Password</enum>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
       </property>
       <property name="placeholderText">
        <string>Enter your raise.dev password</string>
@@ -70,6 +76,13 @@
      </widget>
     </item>
     <item>
+     <widget class="QPushButton" name="reloadSerialPortsButton">
+      <property name="text">
+       <string>Reload serial ports</string>
+      </property>
+     </widget>
+    </item>
+    <item>
      <widget class="QPushButton" name="monitorButton">
       <property name="enabled">
        <bool>false</bool>
@@ -91,6 +104,12 @@
     </item>
     <item>
      <widget class="QPlainTextEdit" name="outputEdit">
+      <property name="minimumSize">
+       <size>
+        <width>400</width>
+        <height>120</height>
+       </size>
+      </property>
       <property name="frameShadow">
        <enum>QFrame::Sunken</enum>
       </property>
@@ -109,7 +128,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>333</width>
+     <width>424</width>
      <height>24</height>
     </rect>
    </property>


### PR DESCRIPTION
- provide button for reloading serial ports (e.g. after plugging in device)
- download firmware to file in cache directory
- use `esptool.py` to flash the firmware
- enable/disable buttons as makes sense
- use monospace font for output pane